### PR TITLE
Add so101-nexus

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ If you find this repo useful, please consider STARing this list and feel free to
 * [DoorGym](https://github.com/PSVL/DoorGym)
 * [RoboHive](https://github.com/vikashplus/robohive)
 * [mujoco_menagerie: High-quality models for MuJoCo](https://github.com/google-deepmind/mujoco_menagerie)
+* [so101-nexus](https://github.com/johnsutor/so101-nexus): Full-stack robot learning for the SO-101 arm (teleoperation, imitation learning, RL) in MuJoCo, with a GPU-parallel NVIDIA Warp backend.
 
 ### SAPIEN-based
 * [ManiSkill3](https://github.com/haosulab/ManiSkill)


### PR DESCRIPTION
Adds so101-nexus under Benchmarks, MuJoCo-based. SO-101 arm library with Gym/MuJoCo environments, teleop, IL, and RL (optional Warp backend).